### PR TITLE
Add visual indication for colliding vehicles

### DIFF
--- a/src/road/common.py
+++ b/src/road/common.py
@@ -120,7 +120,8 @@ class Update(IntEnum):
 
     ADDED = 0
     REMOVED = 1
-    MODIFIED = 2
+    MOVED = 2
+    STATE_CHANGED = 3
 
 
 class Updateable(metaclass=ABCMeta):

--- a/src/road/graphics.py
+++ b/src/road/graphics.py
@@ -1,4 +1,5 @@
 import random
+from collections import namedtuple
 from enum import IntEnum
 from typing import Dict, Tuple
 
@@ -135,6 +136,9 @@ class RoadScreen(sprite.LayeredDirty):
 ###########
 
 
+SpriteState = namedtuple("SpriteState", ["image", "rect"])
+
+
 class BackgroundSprite(sprite.DirtySprite):
     """Background Sprite"""
 
@@ -250,51 +254,51 @@ class VehicleSprite(sprite.DirtySprite):
     def __init__(self, config, x, y):
         sprite.DirtySprite.__init__(self)
 
-        self.config = config
-
-        self.image, self.rect = self._image(
-            x, y, config.RANDOMIZE_VEHICLE_COLOR
+        self.color = (
+            random_color(150, 255)
+            if config.RANDOMIZE_VEHICLE_COLOR
+            else Color.VEHICLE_DEFAULT
         )
+        self.radius = config.VEHICLE_RADIUS
+
+        self.NORMAL_STATE = self._image(x, y, self.color, self.radius)
+        self.COLLIDED_STATE = self._image(
+            x, y, self.color, self.radius, width=2
+        )
+        self.set_state(collided=False)
 
         # Required attributes to add to LayeredDirty
         self.dirty = 1
         self.visible = 1
         self.blendmode = 0
 
-    def _image(self, x, y, randomize_color):
+    def _image(self, x, y, color, radius, width=0) -> SpriteState:
         """Create vehicle image"""
-        image = pygame.Surface(
-            [
-                self.config.VEHICLE_RADIUS * 2 + 1,
-                self.config.VEHICLE_RADIUS * 2 + 1,
-            ]
-        )
+        image = pygame.Surface([radius * 2 + 1, radius * 2 + 1])
 
-        color = (
-            random_color(150, 255)
-            if randomize_color
-            else Color.VEHICLE_DEFAULT
-        )
         pygame.draw.circle(
-            image,
-            color,
-            (self.config.VEHICLE_RADIUS, self.config.VEHICLE_RADIUS),
-            radius=self.config.VEHICLE_RADIUS,
+            image, color, (radius, radius), radius=radius, width=width,
         )
 
         rect = image.get_rect()
-        rect.x, rect.y = (
-            x - self.config.VEHICLE_RADIUS,
-            y - self.config.VEHICLE_RADIUS,
-        )
+        rect.x, rect.y = (x - radius, y - radius)
 
-        return image, rect
+        return SpriteState(image, rect)
+
+    def set_state(self, collided: bool):
+        self.image, self.rect = (
+            self.COLLIDED_STATE if collided else self.NORMAL_STATE
+        )
 
     def update(self, x, y):
         """Update vehicle location"""
-        self.rect.x, self.rect.y = (
-            x - self.config.VEHICLE_RADIUS,
-            y - self.config.VEHICLE_RADIUS,
+        self.NORMAL_STATE.rect.x, self.NORMAL_STATE.rect.y = (
+            x - self.radius,
+            y - self.radius,
+        )
+        self.COLLIDED_STATE.rect.x, self.COLLIDED_STATE.rect.y = (
+            x - self.radius,
+            y - self.radius,
         )
         self.dirty = 1
 

--- a/src/road/graphics.py
+++ b/src/road/graphics.py
@@ -96,7 +96,7 @@ class RoadScreen(sprite.LayeredDirty):
                 self.tiles[(r, c)] = sprite
                 self.add(sprite, layer=RoadScreenLayers.TILES)
 
-            elif u_type == Update.MODIFIED:
+            elif u_type == Update.STATE_CHANGED:
                 self.tiles[(r, c)].update(r, c, tile_type)
 
     def _update_graph(self):
@@ -121,14 +121,20 @@ class RoadScreen(sprite.LayeredDirty):
         updates = self.network.traffic.get_updates()
 
         # Update vehicles
-        for u_type, (id, x, y) in updates:
+        for u_type, params in updates:
             if u_type == Update.ADDED:
+                id, x, y = params
                 sprite = VehicleSprite(self.config, x, y)
                 self.vehicles[id] = sprite
                 self.add(sprite, layer=RoadScreenLayers.VEHICLES)
 
-            elif u_type == Update.MODIFIED:
+            elif u_type == Update.MOVED:
+                id, x, y = params
                 self.vehicles[id].update(x, y)
+
+            elif u_type == Update.STATE_CHANGED:
+                id, collided = params
+                self.vehicles[id].set_state(collided)
 
 
 ###########

--- a/src/road/grid.py
+++ b/src/road/grid.py
@@ -68,7 +68,7 @@ class TileGrid(Updateable):
 
         if new_type != old_type:
             self.grid[r][c] = new_type
-            u_type = Update.ADDED if added else Update.MODIFIED
+            u_type = Update.ADDED if added else Update.STATE_CHANGED
             self.updates.append((u_type, (r, c, new_type)))
 
     def evaluate_tile_type(self, r, c, added=False):

--- a/src/road/traffic.py
+++ b/src/road/traffic.py
@@ -75,8 +75,9 @@ class Traffic(Updateable):
             x, y = v._world_coords
             updates.append((Update.MOVED, (v._id, x, y)))
 
-            collided = self.collision_tracker.has_collision(v._id)
-            updates.append((Update.STATE_CHANGED, (v._id, collided)))
+            if self.config.DEBUG.DISPLAY_VEHICLE_COLLISIONS:
+                collided = self.collision_tracker.has_collision(v._id)
+                updates.append((Update.STATE_CHANGED, (v._id, collided)))
 
         self.updates = []
         return updates

--- a/src/road/traffic.py
+++ b/src/road/traffic.py
@@ -70,10 +70,13 @@ class Traffic(Updateable):
         """Get updates and clear updates queue"""
         updates = self.updates
 
-        # For now, always assume a Vehicle has moved
+        # For now, always update vehicles
         for v in self.vehicles:
             x, y = v._world_coords
-            updates.append((Update.MODIFIED, (v._id, x, y)))
+            updates.append((Update.MOVED, (v._id, x, y)))
+
+            collided = self.collision_tracker.has_collision(v._id)
+            updates.append((Update.STATE_CHANGED, (v._id, collided)))
 
         self.updates = []
         return updates

--- a/src/settings.toml
+++ b/src/settings.toml
@@ -18,7 +18,6 @@ stress_test = false
     display_travel_edges = false
     display_vehicle_collisions = false
 
-
 [development]
 # Graphics
 randomize_vehicle_color = true

--- a/src/settings.toml
+++ b/src/settings.toml
@@ -16,6 +16,7 @@ stress_test = false
 
     [default.debug]
     display_travel_edges = false
+    display_vehicle_collisions = false
 
 
 [development]
@@ -26,5 +27,6 @@ stress_test = false
 
     [development.debug]
     display_travel_edges = true
+    display_vehicle_collisions = true
 
 [production]


### PR DESCRIPTION
#34 

Vehicles now become a hollow circle when debug.display_vehicle_collisions is set in settings.toml.